### PR TITLE
Add GD watermarking to uploaded images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,14 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     curl \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libwebp-dev \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
-    && docker-php-ext-install pdo pdo_sqlite pdo_mysql \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install pdo pdo_sqlite pdo_mysql gd \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/Dockerfile.ssl
+++ b/Dockerfile.ssl
@@ -25,7 +25,12 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     git \
-    && docker-php-ext-install pdo pdo_sqlite pdo_mysql \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libwebp-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install pdo pdo_sqlite pdo_mysql gd \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/app/Services/UploadService.php
+++ b/app/Services/UploadService.php
@@ -8,6 +8,7 @@ class UploadService
 {
     protected const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
     protected const DEFAULT_UPLOAD_DIR = 'uploads/images';
+    protected const DEFAULT_WATERMARK_TEXT = 'PHP App - tdev.app';
 
     public static function uploadImage(
         array $file,
@@ -25,6 +26,9 @@ class UploadService
         if (!move_uploaded_file($file['tmp_name'], $filePath)) {
             throw new Exception('Failed to save file');
         }
+
+        // Apply watermark to the uploaded image
+        static::addWatermark($filePath, $file['type']);
 
         return '/' . $uploadDir . '/' . $filename;
     }
@@ -64,5 +68,105 @@ class UploadService
     private static function getFullUploadPath(string $uploadDir): string
     {
         return __DIR__ . '/../../public/' . $uploadDir . '/';
+    }
+
+    /**
+     * Add watermark to uploaded image using GD
+     */
+    public static function addWatermark(
+        string $filePath,
+        string $mimeType,
+        string $watermarkText = self::DEFAULT_WATERMARK_TEXT
+    ): void {
+        // Check if GD extension is available
+        if (!extension_loaded('gd')) {
+            error_log('GD extension not available - skipping watermark');
+            return;
+        }
+
+        // Create image resource based on mime type
+        $image = null;
+        switch ($mimeType) {
+            case 'image/jpeg':
+                $image = imagecreatefromjpeg($filePath);
+                break;
+            case 'image/png':
+                $image = imagecreatefrompng($filePath);
+                break;
+            case 'image/gif':
+                $image = imagecreatefromgif($filePath);
+                break;
+            case 'image/webp':
+                $image = imagecreatefromwebp($filePath);
+                break;
+            default:
+                error_log("Unsupported image type for watermarking: {$mimeType}");
+                return;
+        }
+
+        if (!$image) {
+            error_log("Failed to create image resource from: {$filePath}");
+            return;
+        }
+
+        // Get image dimensions
+        $imageWidth = imagesx($image);
+        $imageHeight = imagesy($image);
+
+        // Create text color (white with transparency)
+        $textColor = imagecolorallocatealpha($image, 255, 255, 255, 50);
+
+        // Create shadow color (black with transparency)
+        $shadowColor = imagecolorallocatealpha($image, 0, 0, 0, 70);
+
+        // Calculate text position (bottom left with padding)
+        $padding = 20;
+        $font = static::getDefaultFont();
+        $fontHeight = imagefontheight($font);
+
+        $x = $padding;
+        $y = $imageHeight - $padding - $fontHeight;
+
+        // Add shadow (offset by 2 pixels)
+        imagestring($image, $font, $x + 2, $y + 2, $watermarkText, $shadowColor);
+
+        // Add main text
+        imagestring($image, $font, $x, $y, $watermarkText, $textColor);
+
+        // Save the watermarked image
+        switch ($mimeType) {
+            case 'image/jpeg':
+                imagejpeg($image, $filePath, 90); // 90% quality
+                break;
+            case 'image/png':
+                imagepng($image, $filePath, 8); // Compression level 8
+                break;
+            case 'image/gif':
+                imagegif($image, $filePath);
+                break;
+            case 'image/webp':
+                imagewebp($image, $filePath, 90); // 90% quality
+                break;
+        }
+
+        // Clean up memory
+        imagedestroy($image);
+    }
+
+    /**
+     * Get default font for watermarking
+     */
+    private static function getDefaultFont(): int
+    {
+        // Use built-in font if TTF not available
+        return 5; // Built-in font 5 (largest)
+    }
+
+    /**
+     * Check if GD extension is available
+     */
+    public static function isWatermarkingAvailable(): bool
+    {
+        return extension_loaded('gd');
     }
 }


### PR DESCRIPTION
### Summary
  - Enhanced image upload functionality to automatically apply watermarks to all uploaded images
  - Added Docker support for GD extension and image processing libraries
  - Implemented comprehensive watermarking with support for multiple image formats

  ### Changes Made

  #### Docker Configuration
  - Added GD extension dependencies (FreeType, JPEG, PNG, WebP libraries)
  - Configured PHP GD extension with modern image format support

  #### UploadService Enhancement
  - Added `addWatermark()` method with multi-format support (JPEG, PNG, GIF, WebP)
  - Implemented automatic watermark application on image upload
  - Added graceful fallback when GD extension is unavailable
  - Watermark features:
    - Bottom-left positioning with padding
    - White text with black shadow for visibility
    - Customizable watermark text (default: "PHP App - tdev.app")
    - Quality preservation for different formats

  ### Technical Details
  - **Supported formats**: JPEG, PNG, GIF, WebP
  - **Watermark position**: Bottom-left with 20px padding
  - **Error handling**: Logs warnings and continues without watermarking if GD unavailable
  - **Memory management**: Proper resource cleanup after processing
  - **Quality settings**: 90% for JPEG/WebP, compression level 8 for PNG
