### PR TITLE
Fix updated_at auto-update when incrementing post views

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -79,7 +79,7 @@ class Post extends Model
         $db = App::get('database');
 
         $db->query(
-            query: "UPDATE " . static::$table . " SET views = views + 1 WHERE id = ?",
+            query: "UPDATE " . static::$table . " SET views = views + 1, updated_at = updated_at WHERE id = ?",
             params: [$id]
         );
     }


### PR DESCRIPTION
  Prevent automatic updated_at timestamp update when incrementing view count
  by explicitly setting updated_at = updated_at in the UPDATE query. This
  ensures only the views column is modified without changing the last
  modification timestamp.